### PR TITLE
Use founder email env variable in ProtectedRoute

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Application de diagnostic énergétique basée sur le Human Design pour les femm
    ```
    VITE_SUPABASE_URL=votre_url_supabase
    VITE_SUPABASE_ANON_KEY=votre_clé_anon_supabase
+   VITE_FOUNDER_EMAIL=email_de_la_fondatrice
    ```
+
+   - `VITE_FOUNDER_EMAIL` : adresse email de la fondatrice disposant d'un accès administrateur permanent.
 
 ### Développement
 

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -11,22 +11,21 @@ interface ProtectedRouteProps {
 const ProtectedRoute = ({ children, requireAdmin = false, requireSuperAdmin = false }: ProtectedRouteProps) => {
   const { isAuthenticated, user } = useAuthStore();
   const location = useLocation();
+  const founderEmail = import.meta.env.VITE_FOUNDER_EMAIL;
 
   if (!isAuthenticated) {
     // Rediriger vers login avec l'URL de retour
     return <Navigate to="/login" state={{ returnTo: location.pathname }} replace />;
   }
 
-  if (requireSuperAdmin && user?.role !== 'super_admin' && user?.email !== 'christel.aplogan@gmail.com') {
-    // Seul le super admin ou Christel peut accéder
+  if (requireSuperAdmin && user?.role !== 'super_admin' && user?.email !== founderEmail) {
+    // Seul le super admin ou la fondatrice peut accéder
     return <Navigate to="/dashboard" replace />;
   }
 
-  if (requireAdmin && user?.role !== 'admin') {
-    // Vérifier si c'est Christel (fondatrice) qui a toujours accès admin
-    if (user?.email !== 'christel.aplogan@gmail.com') {
-      return <Navigate to="/dashboard" replace />;
-    }
+  if (requireAdmin && user?.role !== 'admin' && user?.email !== founderEmail) {
+    // Vérifier si c'est l'email de la fondatrice qui a toujours accès admin
+    return <Navigate to="/dashboard" replace />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- allow founder access via `VITE_FOUNDER_EMAIL` instead of hardcoded address
- document `VITE_FOUNDER_EMAIL` in README

## Testing
- `npm run lint` *(fails: Unexpected any, Unexpected lexical declaration...)*

------
https://chatgpt.com/codex/tasks/task_b_68908ff0eb708320ae6ffee140f9fc26